### PR TITLE
Some Test Helpers

### DIFF
--- a/src/utils/HookTest.sol
+++ b/src/utils/HookTest.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import "forge-std/Test.sol";
+import {TestERC20} from "@uniswap/v4-core/contracts/test/TestERC20.sol";
+import {PoolManager} from "@uniswap/v4-core/contracts/PoolManager.sol";
+import {IPoolManager} from "@uniswap/v4-core/contracts/interfaces/IPoolManager.sol";
+import {PoolModifyPositionTest} from "@uniswap/v4-core/contracts/test/PoolModifyPositionTest.sol";
+import {PoolSwapTest} from "@uniswap/v4-core/contracts/test/PoolSwapTest.sol";
+import {PoolDonateTest} from "@uniswap/v4-core/contracts/test/PoolDonateTest.sol";
+
+/// @notice Contract to initialize some test helpers
+/// @dev Minimal initialization. Inheriting contract should set up pools and provision liquidity
+contract HookTest is Test {    
+    PoolManager manager;
+    PoolModifyPositionTest modifyPositionRouter;
+    PoolSwapTest swapRouter;
+    PoolDonateTest donateRouter;
+    TestERC20 token0;
+    TestERC20 token1;
+
+    function initHookTestEnv() public {
+        uint256 amount = 2**128;
+        TestERC20 _tokenA = new TestERC20(amount);
+        TestERC20 _tokenB = new TestERC20(amount);
+
+        // pools alphabetically sort tokens by address
+        // so align `token0` with `pool.token0` for consistency
+        if (address(_tokenA) < address(_tokenB)) {
+            token0 = _tokenA;
+            token1 = _tokenB;
+        } else {
+            token0 = _tokenB;
+            token1 = _tokenA;
+        }
+        manager = new PoolManager(500000);
+
+        // Helpers for interacting with the pool
+        modifyPositionRouter = new PoolModifyPositionTest(IPoolManager(address(manager)));
+        swapRouter = new PoolSwapTest(IPoolManager(address(manager)));
+        donateRouter = new PoolDonateTest(IPoolManager(address(manager)));
+
+        // Approve for liquidity provision
+        token0.approve(address(modifyPositionRouter), amount);
+        token1.approve(address(modifyPositionRouter), amount);
+
+        // Approve for swapping
+        token0.approve(address(swapRouter), amount);
+        token1.approve(address(swapRouter), amount);
+    }
+
+    function etchHook(address _implementation, address _hook) internal {
+        (, bytes32[] memory writes) = vm.accesses(_implementation);
+        vm.etch(_hook, _implementation.code);
+        // for each storage key that was written during the hook implementation, copy the value over
+        unchecked {
+            for (uint256 i = 0; i < writes.length; i++) {
+                bytes32 slot = writes[i];
+                vm.store(_hook, slot, vm.load(_implementation, slot));
+            }
+        }
+    }
+}

--- a/src/utils/HookTest.sol
+++ b/src/utils/HookTest.sol
@@ -2,16 +2,19 @@
 pragma solidity ^0.8.15;
 
 import "forge-std/Test.sol";
-import {TestERC20} from "@uniswap/v4-core/contracts/test/TestERC20.sol";
+
 import {PoolManager} from "@uniswap/v4-core/contracts/PoolManager.sol";
 import {IPoolManager} from "@uniswap/v4-core/contracts/interfaces/IPoolManager.sol";
 import {PoolModifyPositionTest} from "@uniswap/v4-core/contracts/test/PoolModifyPositionTest.sol";
 import {PoolSwapTest} from "@uniswap/v4-core/contracts/test/PoolSwapTest.sol";
 import {PoolDonateTest} from "@uniswap/v4-core/contracts/test/PoolDonateTest.sol";
 
+import {TestERC20} from "@uniswap/v4-core/contracts/test/TestERC20.sol";
+import {TickMath} from "@uniswap/v4-core/contracts/libraries/TickMath.sol";
+
 /// @notice Contract to initialize some test helpers
 /// @dev Minimal initialization. Inheriting contract should set up pools and provision liquidity
-contract HookTest is Test {    
+contract HookTest is Test {
     PoolManager manager;
     PoolModifyPositionTest modifyPositionRouter;
     PoolSwapTest swapRouter;
@@ -19,8 +22,11 @@ contract HookTest is Test {
     TestERC20 token0;
     TestERC20 token1;
 
+    uint160 public constant MIN_PRICE_LIMIT = TickMath.MIN_SQRT_RATIO + 1;
+    uint160 public constant MAX_PRICE_LIMIT = TickMath.MAX_SQRT_RATIO - 1;
+
     function initHookTestEnv() public {
-        uint256 amount = 2**128;
+        uint256 amount = 2 ** 128;
         TestERC20 _tokenA = new TestERC20(amount);
         TestERC20 _tokenB = new TestERC20(amount);
 
@@ -59,5 +65,18 @@ contract HookTest is Test {
                 vm.store(_hook, slot, vm.load(_implementation, slot));
             }
         }
+    }
+
+    function swap(IPoolManager.PoolKey memory key, int256 amountSpecified, bool zeroForOne) internal {
+        IPoolManager.SwapParams memory params = IPoolManager.SwapParams({
+            zeroForOne: zeroForOne,
+            amountSpecified: amountSpecified,
+            sqrtPriceLimitX96: zeroForOne ? MIN_PRICE_LIMIT : MAX_PRICE_LIMIT // unlimited impact
+        });
+
+        PoolSwapTest.TestSettings memory testSettings =
+            PoolSwapTest.TestSettings({withdrawTokens: true, settleUsingTransfer: true});
+
+        swapRouter.swap(key, params, testSettings);
     }
 }

--- a/test/Counter.t.sol
+++ b/test/Counter.t.sol
@@ -8,7 +8,6 @@ import {Hooks} from "@uniswap/v4-core/contracts/libraries/Hooks.sol";
 import {TickMath} from "@uniswap/v4-core/contracts/libraries/TickMath.sol";
 import {IPoolManager} from "@uniswap/v4-core/contracts/interfaces/IPoolManager.sol";
 import {PoolId} from "@uniswap/v4-core/contracts/libraries/PoolId.sol";
-import {PoolSwapTest} from "@uniswap/v4-core/contracts/test/PoolSwapTest.sol";
 import {Deployers} from "@uniswap/v4-core/test/foundry-tests/utils/Deployers.sol";
 import {CurrencyLibrary, Currency} from "@uniswap/v4-core/contracts/libraries/CurrencyLibrary.sol";
 import {HookTest} from "../src/utils/HookTest.sol";

--- a/test/Counter.t.sol
+++ b/test/Counter.t.sol
@@ -3,52 +3,34 @@ pragma solidity ^0.8.15;
 
 import "forge-std/Test.sol";
 import {GasSnapshot} from "forge-gas-snapshot/GasSnapshot.sol";
-import {TestERC20} from "@uniswap/v4-core/contracts/test/TestERC20.sol";
-import {IERC20Minimal} from "@uniswap/v4-core/contracts/interfaces/external/IERC20Minimal.sol";
 import {IHooks} from "@uniswap/v4-core/contracts/interfaces/IHooks.sol";
 import {Hooks} from "@uniswap/v4-core/contracts/libraries/Hooks.sol";
 import {TickMath} from "@uniswap/v4-core/contracts/libraries/TickMath.sol";
-import {PoolManager} from "@uniswap/v4-core/contracts/PoolManager.sol";
 import {IPoolManager} from "@uniswap/v4-core/contracts/interfaces/IPoolManager.sol";
 import {PoolId} from "@uniswap/v4-core/contracts/libraries/PoolId.sol";
-import {PoolModifyPositionTest} from "@uniswap/v4-core/contracts/test/PoolModifyPositionTest.sol";
 import {PoolSwapTest} from "@uniswap/v4-core/contracts/test/PoolSwapTest.sol";
-import {PoolDonateTest} from "@uniswap/v4-core/contracts/test/PoolDonateTest.sol";
 import {Deployers} from "@uniswap/v4-core/test/foundry-tests/utils/Deployers.sol";
 import {CurrencyLibrary, Currency} from "@uniswap/v4-core/contracts/libraries/CurrencyLibrary.sol";
+import {HookTest} from "../src/utils/HookTest.sol";
 import {Counter} from "../src/Counter.sol";
 import {CounterImplementation} from "./implementation/CounterImplementation.sol";
 
-contract CounterTest is Test, Deployers, GasSnapshot {
+contract CounterTest is HookTest, Deployers, GasSnapshot {
     using PoolId for IPoolManager.PoolKey;
     using CurrencyLibrary for Currency;
 
     Counter counter = Counter(address(uint160(Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG)));
-    PoolManager manager;
-    PoolModifyPositionTest modifyPositionRouter;
-    PoolSwapTest swapRouter;
-    TestERC20 token0;
-    TestERC20 token1;
     IPoolManager.PoolKey poolKey;
     bytes32 poolId;
 
     function setUp() public {
-        token0 = new TestERC20(2**128);
-        token1 = new TestERC20(2**128);
-        manager = new PoolManager(500000);
+        // creates the pool manager, test tokens, and other utility routers
+        HookTest.initHookTestEnv();
 
         // testing environment requires our contract to override `validateHookAddress`
         // well do that via the Implementation contract to avoid deploying the override with the production contract
         CounterImplementation impl = new CounterImplementation(manager, counter);
-        (, bytes32[] memory writes) = vm.accesses(address(impl));
-        vm.etch(address(counter), address(impl).code);
-        // for each storage key that was written during the hook implementation, copy the value over
-        unchecked {
-            for (uint256 i = 0; i < writes.length; i++) {
-                bytes32 slot = writes[i];
-                vm.store(address(counter), slot, vm.load(address(impl), slot));
-            }
-        }
+        etchHook(address(impl), address(counter));
 
         // Create the pool
         poolKey = IPoolManager.PoolKey(
@@ -57,24 +39,12 @@ contract CounterTest is Test, Deployers, GasSnapshot {
         poolId = PoolId.toId(poolKey);
         manager.initialize(poolKey, SQRT_RATIO_1_1);
 
-        // Helpers for interacting with the pool
-        modifyPositionRouter = new PoolModifyPositionTest(IPoolManager(address(manager)));
-        swapRouter = new PoolSwapTest(IPoolManager(address(manager)));
-
         // Provide liquidity to the pool
-        token0.approve(address(modifyPositionRouter), 100 ether);
-        token1.approve(address(modifyPositionRouter), 100 ether);
-        token0.mint(address(this), 100 ether);
-        token1.mint(address(this), 100 ether);
         modifyPositionRouter.modifyPosition(poolKey, IPoolManager.ModifyPositionParams(-60, 60, 10 ether));
         modifyPositionRouter.modifyPosition(poolKey, IPoolManager.ModifyPositionParams(-120, 120, 10 ether));
         modifyPositionRouter.modifyPosition(
             poolKey, IPoolManager.ModifyPositionParams(TickMath.minUsableTick(60), TickMath.maxUsableTick(60), 10 ether)
         );
-
-        // Approve for swapping
-        token0.approve(address(swapRouter), 100 ether);
-        token1.approve(address(swapRouter), 100 ether);
     }
 
     function testCounterHooks() public {

--- a/test/Counter.t.sol
+++ b/test/Counter.t.sol
@@ -23,9 +23,7 @@ contract CounterTest is Test, Deployers, GasSnapshot {
     using PoolId for IPoolManager.PoolKey;
     using CurrencyLibrary for Currency;
 
-    Counter counter = Counter(
-        address(uint160(Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG))
-    );
+    Counter counter = Counter(address(uint160(Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG)));
     PoolManager manager;
     PoolModifyPositionTest modifyPositionRouter;
     PoolSwapTest swapRouter;
@@ -53,7 +51,9 @@ contract CounterTest is Test, Deployers, GasSnapshot {
         }
 
         // Create the pool
-        poolKey = IPoolManager.PoolKey(Currency.wrap(address(token0)), Currency.wrap(address(token1)), 3000, 60, IHooks(counter));
+        poolKey = IPoolManager.PoolKey(
+            Currency.wrap(address(token0)), Currency.wrap(address(token1)), 3000, 60, IHooks(counter)
+        );
         poolId = PoolId.toId(poolKey);
         manager.initialize(poolKey, SQRT_RATIO_1_1);
 
@@ -80,21 +80,17 @@ contract CounterTest is Test, Deployers, GasSnapshot {
     function testCounterHooks() public {
         assertEq(counter.beforeSwapCount(), 0);
         assertEq(counter.afterSwapCount(), 0);
-        
+
         // Perform a test swap //
         IPoolManager.SwapParams memory params =
             IPoolManager.SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_RATIO_1_2});
 
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({withdrawTokens: true, settleUsingTransfer: true});
-        
-        swapRouter.swap(
-            poolKey,
-            params,
-            testSettings
-        );
+
+        swapRouter.swap(poolKey, params, testSettings);
         // ------------------- //
-        
+
         assertEq(counter.beforeSwapCount(), 1);
         assertEq(counter.afterSwapCount(), 1);
     }

--- a/test/Counter.t.sol
+++ b/test/Counter.t.sol
@@ -52,13 +52,9 @@ contract CounterTest is HookTest, Deployers, GasSnapshot {
         assertEq(counter.afterSwapCount(), 0);
 
         // Perform a test swap //
-        IPoolManager.SwapParams memory params =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_RATIO_1_2});
-
-        PoolSwapTest.TestSettings memory testSettings =
-            PoolSwapTest.TestSettings({withdrawTokens: true, settleUsingTransfer: true});
-
-        swapRouter.swap(poolKey, params, testSettings);
+        int256 amount = 100;
+        bool zeroForOne = true;
+        swap(poolKey, amount, zeroForOne);
         // ------------------- //
 
         assertEq(counter.beforeSwapCount(), 1);

--- a/test/Counter.t.sol
+++ b/test/Counter.t.sol
@@ -17,7 +17,7 @@ import {PoolDonateTest} from "@uniswap/v4-core/contracts/test/PoolDonateTest.sol
 import {Deployers} from "@uniswap/v4-core/test/foundry-tests/utils/Deployers.sol";
 import {CurrencyLibrary, Currency} from "@uniswap/v4-core/contracts/libraries/CurrencyLibrary.sol";
 import {Counter} from "../src/Counter.sol";
-import {CounterImplementation} from "../src/implementation/CounterImplementation.sol";
+import {CounterImplementation} from "./implementation/CounterImplementation.sol";
 
 contract CounterTest is Test, Deployers, GasSnapshot {
     using PoolId for IPoolManager.PoolKey;

--- a/test/implementation/CounterImplementation.sol
+++ b/test/implementation/CounterImplementation.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
-import {Counter} from "../Counter.sol";
+import {Counter} from "../../src/Counter.sol";
 
 import {BaseHook} from "v4-periphery/BaseHook.sol";
 import {IPoolManager} from "@uniswap/v4-core/contracts/interfaces/IPoolManager.sol";


### PR DESCRIPTION
Reorganized some test helpers into `HookTest`

* Creates pool manager, test tokens, and routing contracts (swaps / LPs)
* `etchHook()` for etching the hook to the "mined" address
* `swap()` to streamline test swaps against a pool