### PR TITLE
Update v4 Dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "lib/v4-periphery"]
+	path = lib/v4-periphery
+	url = https://github.com/uniswap/v4-periphery

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
-[submodule "lib/v4-periphery"]
-	path = lib/v4-periphery
-	url = https://github.com/uniswap/v4-periphery

--- a/script/Counter.s.sol
+++ b/script/Counter.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.19;
 
 import "forge-std/Script.sol";
 import {Hooks} from "@uniswap/v4-core/contracts/libraries/Hooks.sol";

--- a/script/Counter.s.sol
+++ b/script/Counter.s.sol
@@ -66,7 +66,7 @@ contract CounterScript is Script {
 
     function etchHook(address _implementation, address _hook) internal {
         (, bytes32[] memory writes) = vm.accesses(_implementation);
-        
+
         // courtesy of horsefacts
         // https://github.com/farcasterxyz/contracts/blob/de8aa0723a5c83b5682fd6d3a1123ea5fced179e/script/Deploy.s.sol#L54
         string[] memory command = new string[](5);
@@ -76,7 +76,7 @@ contract CounterScript is Script {
         command[3] = vm.toString(_hook);
         command[4] = vm.toString(_implementation.code);
         vm.ffi(command);
-        
+
         // for each storage key that was written during the hook implementation, copy the value over
         unchecked {
             for (uint256 i = 0; i < writes.length; i++) {

--- a/src/Counter.sol
+++ b/src/Counter.sol
@@ -5,11 +5,12 @@ import {BaseHook} from "v4-periphery/BaseHook.sol";
 
 import {Hooks} from "@uniswap/v4-core/contracts/libraries/Hooks.sol";
 import {IPoolManager} from "@uniswap/v4-core/contracts/interfaces/IPoolManager.sol";
-import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/contracts/libraries/PoolId.sol";
+import {PoolKey} from "@uniswap/v4-core/contracts/types/PoolKey.sol";
+import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/contracts/types/PoolId.sol";
 import {BalanceDelta} from "@uniswap/v4-core/contracts/types/BalanceDelta.sol";
 
 contract Counter is BaseHook {
-    using PoolIdLibrary for IPoolManager.PoolKey;
+    using PoolIdLibrary for PoolKey;
 
     uint256 public beforeSwapCount;
     uint256 public afterSwapCount;
@@ -29,7 +30,7 @@ contract Counter is BaseHook {
         });
     }
 
-    function beforeSwap(address, IPoolManager.PoolKey calldata, IPoolManager.SwapParams calldata)
+    function beforeSwap(address, PoolKey calldata, IPoolManager.SwapParams calldata, bytes calldata)
         external
         override
         returns (bytes4)
@@ -38,7 +39,7 @@ contract Counter is BaseHook {
         return BaseHook.beforeSwap.selector;
     }
 
-    function afterSwap(address, IPoolManager.PoolKey calldata, IPoolManager.SwapParams calldata, BalanceDelta)
+    function afterSwap(address, PoolKey calldata, IPoolManager.SwapParams calldata, BalanceDelta, bytes calldata)
         external
         override
         returns (bytes4)

--- a/src/Counter.sol
+++ b/src/Counter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.19;
 
 import {BaseHook} from "v4-periphery/BaseHook.sol";
 

--- a/src/Counter.sol
+++ b/src/Counter.sol
@@ -15,14 +15,17 @@ contract Counter is BaseHook {
     uint256 public beforeSwapCount;
     uint256 public afterSwapCount;
 
+    uint256 public beforeModifyPositionCount;
+    uint256 public afterModifyPositionCount;
+
     constructor(IPoolManager _poolManager) BaseHook(_poolManager) {}
 
     function getHooksCalls() public pure override returns (Hooks.Calls memory) {
         return Hooks.Calls({
             beforeInitialize: false,
             afterInitialize: false,
-            beforeModifyPosition: false,
-            afterModifyPosition: false,
+            beforeModifyPosition: true,
+            afterModifyPosition: true,
             beforeSwap: true,
             afterSwap: true,
             beforeDonate: false,
@@ -46,5 +49,25 @@ contract Counter is BaseHook {
     {
         afterSwapCount++;
         return BaseHook.afterSwap.selector;
+    }
+
+    function beforeModifyPosition(address, PoolKey calldata, IPoolManager.ModifyPositionParams calldata, bytes calldata)
+        external
+        override
+        returns (bytes4)
+    {
+        beforeModifyPositionCount++;
+        return BaseHook.beforeModifyPosition.selector;
+    }
+
+    function afterModifyPosition(
+        address,
+        PoolKey calldata,
+        IPoolManager.ModifyPositionParams calldata,
+        BalanceDelta,
+        bytes calldata
+    ) external override returns (bytes4) {
+        afterModifyPositionCount++;
+        return BaseHook.afterModifyPosition.selector;
     }
 }

--- a/test/Counter.t.sol
+++ b/test/Counter.t.sol
@@ -7,19 +7,20 @@ import {IHooks} from "@uniswap/v4-core/contracts/interfaces/IHooks.sol";
 import {Hooks} from "@uniswap/v4-core/contracts/libraries/Hooks.sol";
 import {TickMath} from "@uniswap/v4-core/contracts/libraries/TickMath.sol";
 import {IPoolManager} from "@uniswap/v4-core/contracts/interfaces/IPoolManager.sol";
-import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/contracts/libraries/PoolId.sol";
+import {PoolKey} from "@uniswap/v4-core/contracts/types/PoolKey.sol";
+import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/contracts/types/PoolId.sol";
 import {Deployers} from "@uniswap/v4-core/test/foundry-tests/utils/Deployers.sol";
-import {CurrencyLibrary, Currency} from "@uniswap/v4-core/contracts/libraries/CurrencyLibrary.sol";
+import {CurrencyLibrary, Currency} from "@uniswap/v4-core/contracts/types/Currency.sol";
 import {HookTest} from "./utils/HookTest.sol";
 import {Counter} from "../src/Counter.sol";
 import {CounterImplementation} from "./implementation/CounterImplementation.sol";
 
 contract CounterTest is HookTest, Deployers, GasSnapshot {
-    using PoolIdLibrary for IPoolManager.PoolKey;
+    using PoolIdLibrary for PoolKey;
     using CurrencyLibrary for Currency;
 
     Counter counter = Counter(address(uint160(Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG)));
-    IPoolManager.PoolKey poolKey;
+    PoolKey poolKey;
     PoolId poolId;
 
     function setUp() public {
@@ -32,11 +33,9 @@ contract CounterTest is HookTest, Deployers, GasSnapshot {
         etchHook(address(impl), address(counter));
 
         // Create the pool
-        poolKey = IPoolManager.PoolKey(
-            Currency.wrap(address(token0)), Currency.wrap(address(token1)), 3000, 60, IHooks(counter)
-        );
+        poolKey = PoolKey(Currency.wrap(address(token0)), Currency.wrap(address(token1)), 3000, 60, IHooks(counter));
         poolId = poolKey.toId();
-        manager.initialize(poolKey, SQRT_RATIO_1_1);
+        manager.initialize(poolKey, SQRT_RATIO_1_1, ZERO_BYTES);
 
         // Provide liquidity to the pool
         modifyPositionRouter.modifyPosition(poolKey, IPoolManager.ModifyPositionParams(-60, 60, 10 ether));

--- a/test/Counter.t.sol
+++ b/test/Counter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.19;
 
 import "forge-std/Test.sol";
 import {GasSnapshot} from "forge-gas-snapshot/GasSnapshot.sol";

--- a/test/Counter.t.sol
+++ b/test/Counter.t.sol
@@ -19,7 +19,14 @@ contract CounterTest is HookTest, Deployers, GasSnapshot {
     using PoolIdLibrary for PoolKey;
     using CurrencyLibrary for Currency;
 
-    Counter counter = Counter(address(uint160(Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG)));
+    Counter counter = Counter(
+        address(
+            uint160(
+                Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG | Hooks.BEFORE_MODIFY_POSITION_FLAG
+                    | Hooks.AFTER_MODIFY_POSITION_FLAG
+            )
+        )
+    );
     PoolKey poolKey;
     PoolId poolId;
 
@@ -46,6 +53,10 @@ contract CounterTest is HookTest, Deployers, GasSnapshot {
     }
 
     function testCounterHooks() public {
+        // positions were created in setup()
+        assertEq(counter.beforeModifyPositionCount(), 3);
+        assertEq(counter.afterModifyPositionCount(), 3);
+
         assertEq(counter.beforeSwapCount(), 0);
         assertEq(counter.afterSwapCount(), 0);
 

--- a/test/utils/HookTest.sol
+++ b/test/utils/HookTest.sol
@@ -5,6 +5,7 @@ import "forge-std/Test.sol";
 
 import {PoolManager} from "@uniswap/v4-core/contracts/PoolManager.sol";
 import {IPoolManager} from "@uniswap/v4-core/contracts/interfaces/IPoolManager.sol";
+import {PoolKey} from "@uniswap/v4-core/contracts/types/PoolKey.sol";
 import {PoolModifyPositionTest} from "@uniswap/v4-core/contracts/test/PoolModifyPositionTest.sol";
 import {PoolSwapTest} from "@uniswap/v4-core/contracts/test/PoolSwapTest.sol";
 import {PoolDonateTest} from "@uniswap/v4-core/contracts/test/PoolDonateTest.sol";
@@ -67,7 +68,7 @@ contract HookTest is Test {
         }
     }
 
-    function swap(IPoolManager.PoolKey memory key, int256 amountSpecified, bool zeroForOne) internal {
+    function swap(PoolKey memory key, int256 amountSpecified, bool zeroForOne) internal {
         IPoolManager.SwapParams memory params = IPoolManager.SwapParams({
             zeroForOne: zeroForOne,
             amountSpecified: amountSpecified,

--- a/test/utils/HookTest.sol
+++ b/test/utils/HookTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.19;
 
 import "forge-std/Test.sol";
 


### PR DESCRIPTION
v4 was updated to support arbitrary calldata on all hook interfaces (woo!)

---

Bonus: added boilerplate for LP hooks in `Counter.sol`